### PR TITLE
Update `geo` crate to fix overflow error present in version <0.25.0

### DIFF
--- a/planetcam/Cargo.toml
+++ b/planetcam/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 cgmath = { version = "0.18.0", git = "https://github.com/rustgd/cgmath", rev = "d5e765db61cf9039cb625a789a59ddf6b6ab2337" }
-geo = "0.24.1"
+geo = "0.29.3"
 mint = "0.5.9"
 
 [dev-dependencies]

--- a/preview/Cargo.toml
+++ b/preview/Cargo.toml
@@ -10,7 +10,7 @@ env_logger = "0.10.0"
 gilrs = "0.10.1"
 indicatif = "0.17.3"
 mint = "0.5.9"
-open-location-code = {version = "0.2.0", git = "https://github.com/fintelia/open-location-code", rev = "07a4dd0d8fc08619979707c985728c4fd07dacae" }
+open-location-code = "0.1.0"
 planetcam = { path = "../planetcam" }
 smaa = { version = "0.9.0", optional = true }
 terra = { path = "..", default-features = false }


### PR DESCRIPTION
When building `terra`, I ran into an overflow error when building the `geo` dependency, which was fixed in v0.25.0: https://github.com/georust/geo/issues/1010.

The proposed fix is to update the `geo` version in the `planetcam` crate to the latest v0.29.3, and to either update the `geo` version in the `open-location-code` fork, or depend on the upstream version of `open-location-code` which seems to have a number of recent updates and doesn't result in `geo` < 0.25.0 being used. I'm not sure though whether there are changes in the fork which are important, so please review this.

I'm using MacOS and Rust version 1.80.0-nightly.

Overflow error:
```bash
error[E0275]: overflow evaluating the requirement `{closure@/Users/X/.cargo/registry/src/index.crates.io-6f17d22bba15001f/geo-0.24.1/src/algorithm/map_coords.rs:855:69: 855:72}: Fn(geo_types::Coord<T>)`
  |
  = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`geo`)
  = note: required for `&{closure@/Users/X/.cargo/registry/src/index.crates.io-6f17d22bba15001f/geo-0.24.1/src/algorithm/map_coords.rs:855:69: 855:72}` to implement `Fn<(geo_types::Coord<T>,)>`
  = note: 128 redundant requirements hidden
  = note: required for `&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&...` to implement `Fn<(geo_types::Coord<T>,)>`
  = note: the full name for the type has been written to '/Users/X/workspace/terra/target/release/deps/geo-1aa2eea29080202e.long-type-6816710008654894887.txt'
  = note: consider using `--verbose` to print the full type name to the console

For more information about this error, try `rustc --explain E0275`.
error: could not compile `geo` (lib) due to 1 previous error
```